### PR TITLE
Fix transfers > 32MiB by handling the block sequence number wrap around gracefully

### DIFF
--- a/lib/tftp/tftp.rb
+++ b/lib/tftp/tftp.rb
@@ -139,7 +139,7 @@ module TFTP
               log :warn, "#{tag} Seq mismatch: #{seq} != #{pkt.seq}"
               return
             end
-            seq += 1
+            seq = (seq + 1) & 0xFFFF #Increment with wrap around at 16 bit boundary, because of tftp block number field size limit.
           end
           sock.send(Packet::DATA.new(seq, '').encode, 0) if io.size % 512 == 0
         rescue ParseError => e


### PR DESCRIPTION
The tftp block number field is only 16 bits wide and will overflow after 65535 512byte blocks.
Because tftp transfers are always sequential clients and servers can allow the field to wrap around.
