### PR TITLE
Implement `tsize` (Transfer Size) option

### DIFF
--- a/lib/tftp/tftp.rb
+++ b/lib/tftp/tftp.rb
@@ -20,15 +20,23 @@ module TFTP
     end
 
     # Read Request
-    RRQ = Base.new(:filename, :mode)
+    RRQ = Base.new(:filename, :mode, :options)
     class RRQ
+      def initialize(filename, mode, options = {})
+        super(filename, mode, options)
+      end
+
       # Convert to binary string.
       def to_str; "\x00\x01" + self.filename + "\x00" + self.mode.to_s + "\x00"; end
     end
 
     # Write Request
-    WRQ = Base.new(:filename, :mode)
+    WRQ = Base.new(:filename, :mode, :options)
     class WRQ
+      def initialize(filename, mode, options = {})
+        super(filename, mode, options)
+      end
+
       def to_str; "\x00\x02" + self.filename + "\x00" + self.mode.to_s + "\x00"; end
     end
 
@@ -52,6 +60,11 @@ module TFTP
       def to_str; "\x00\x05" + [self.code].pack('n') + self.msg + "\x00"; end
     end
 
+    OACK = Base.new(:options)
+    class OACK
+      def to_str; "\x00\x06" + self.options.to_a.flatten.map { |opt| opt.to_s + "\x00" }.join(); end
+    end
+
     # Parse a binary string into a packet.
     # Does some sanity checking, can raise a ParseError.
     def self.parse(data)
@@ -71,8 +84,13 @@ module TFTP
         filename = xs[0]
         mode = xs[1].downcase.to_sym
         raise ParseError, "Unknown mode '#{xs[1].inspect}'" unless [:netascii, :octet].member? mode
-        return RRQ.new(filename, mode) if opcode == 1
-        return WRQ.new(filename, mode)
+        options = {}
+        if xs.length > 2
+          xs << '' unless (xs.length % 2).zero?
+          options = Hash[*xs[2..]]
+        end
+        return RRQ.new(filename, mode, options) if opcode == 1
+        return WRQ.new(filename, mode, options)
       when 3 # data
         seq = payload.unpack('n').first
         block = payload.slice(2, payload.length - 2) || ''
@@ -149,6 +167,20 @@ module TFTP
           return
         end
         log :info, "#{tag} Sent file"
+      end
+
+      def send_oack(tag, sock, options)
+          sock.send(Packet::OACK.new(options).encode, 0)
+          unless IO.select([sock], nil, nil, @timeout)
+            log :warn, "#{tag} Timeout for OACK"
+            return
+          end
+          msg, _ = sock.recvfrom(516, 0)
+          pkt = Packet.parse(msg)
+          if pkt.class != Packet::ACK
+            error_message = pkt.is_a?(Packet::ERROR) ? "ERROR #{pkt.code} - #{pkt.msg}" : pkt.class.to_s
+            log :warn, "#{tag} Expected ACK but got: #{error_message}"
+          end
       end
 
       # Receive data over an established connection.
@@ -246,6 +278,9 @@ module TFTP
           mode = 'r'
           mode += 'b' if req.mode == :octet
           io = File.open(path, mode)
+          if req.options.key?('tsize')
+            send_oack(tag, sock, { 'tsize' => io.stat.size })
+          end
           send(tag, sock, io)
           sock.close
           io.close


### PR DESCRIPTION
I'm using `fx-tftp` for my [ConfigLMM](https://github.com/ConfigLMM/ConfigLMM) tool that can configure systems/software automatically. Specifically for automatic OS install over PXE and unfortunately Grub has a bug that it doesn't work if TFTP server doesn't support `tsize` option.

So this PR implements `tsize` (Transfer Size) option.

Refer to [RFC 2349](https://www.rfc-editor.org/rfc/rfc2349) and [RFC 2347](https://www.rfc-editor.org/rfc/rfc2347)