### PR TITLE
Make `send()` more robust by handling previous ACK

### DIFF
--- a/lib/tftp/tftp.rb
+++ b/lib/tftp/tftp.rb
@@ -129,15 +129,18 @@ module TFTP
               log :warn, "#{tag} Timeout at block ##{seq}"
               return
             end
-            msg, _ = sock.recvfrom(4, 0)
-            pkt = Packet.parse(msg)
-            if pkt.class != Packet::ACK
-              log :warn, "#{tag} Expected ACK but got: #{pkt.class}"
-              return
-            end
-            if pkt.seq != seq
-              log :warn, "#{tag} Seq mismatch: #{seq} != #{pkt.seq}"
-              return
+            loop do
+              msg, _ = sock.recvfrom(4, 0)
+              pkt = Packet.parse(msg)
+              if pkt.class != Packet::ACK
+                log :warn, "#{tag} Expected ACK but got: #{pkt.class}"
+                return
+              end
+              break if pkt.seq == seq
+              if pkt.seq > seq
+                log :warn, "#{tag} Seq mismatch: #{seq} != #{pkt.seq}"
+                return
+              end
             end
             # Increment with wrap around at 16 bit boundary,
             # because of tftp block number field size limit.


### PR DESCRIPTION
Syslinux TFTP sometimes sends previous ACK sequence.
This PR allows such behavior making it work :)

Without this PR it would fail like this
```
ℹ info    [192.168.0.135:49153] New initial packet received
• debug   [192.168.0.135:49153] -> PKT: #<struct TFTP::Packet::RRQ filename="initrd", mode=:octet>
⚠ warning [192.168.0.135:49153:5389 ] Seq mismatch: 53467 != 53466
ℹ info    [192.168.0.135:49153:5389 ] Session ended
```
