### PR TITLE
Fix and improve error messages

### DIFF
--- a/lib/tftp/tftp.rb
+++ b/lib/tftp/tftp.rb
@@ -129,10 +129,11 @@ module TFTP
               log :warn, "#{tag} Timeout at block ##{seq}"
               return
             end
-            msg, _ = sock.recvfrom(4, 0)
+            msg, _ = sock.recvfrom(516, 0)
             pkt = Packet.parse(msg)
             if pkt.class != Packet::ACK
-              log :warn, "#{tag} Expected ACK but got: #{pkt.class}"
+              error_message = pkt.is_a?(Packet::ERROR) ? "ERROR #{pkt.code} - #{pkt.msg}" : pkt.class.to_s
+              log :warn, "#{tag} Expected ACK but got: #{error_message}"
               return
             end
             if pkt.seq != seq
@@ -172,7 +173,8 @@ module TFTP
             msg, _ = sock.recvfrom(516, 0)
             pkt = Packet.parse(msg)
             if pkt.class != Packet::DATA
-              log :warn, "#{tag} Expected DATA but got: #{pkt.class}"
+              error_message = pkt.is_a?(Packet::ERROR) ? "ERROR #{pkt.code} - #{pkt.msg}" : pkt.class.to_s
+              log :warn, "#{tag} Expected DATA but got: #{error_message}"
               return false
             end
             if pkt.seq != seq


### PR DESCRIPTION
Currently because of `sock.recvfrom(4, 0)` only error code bytes were read but not the error message itself.
So `pkt.msg` was always empty.
This PR fixes that and also improves error message to see what client actually sent in `msg`.
